### PR TITLE
Added URN to types.py which was a mistake as this is auto-generated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ gen:
 	rm -fr ${SRC_DIR}/api ${SRC_DIR}/models ${SRC_DIR}/client \
 		&& mkdir -p ${SRC_DIR}/api ${SRC_DIR}/models ${SRC_DIR}/client \
 		&& mv ${ROOT_DIR}/build/sdk_client/ivcap_client/* ${SRC_DIR} \
-		&& mv ${SRC_DIR}/client/errors.py ${SRC_DIR}/client/types.py ${SRC_DIR}
+		&& mv ${SRC_DIR}/client/errors.py ${SRC_DIR}/client/types.py ${SRC_DIR} \
+		&& sed -i '' '1s/^/#\n#### DO NOT EDIT ####\n#\n/' ${SRC_DIR}/types.py ${SRC_DIR}/errors.py
 	rm -r ${ROOT_DIR}/build
 
 add-license:

--- a/src/ivcap_client/__init__.py
+++ b/src/ivcap_client/__init__.py
@@ -15,7 +15,7 @@ try:
 except Exception:
     __version__ = "???" # should only happen when running the local examples
 
-from .ivcap import IVCAP
+from .ivcap import IVCAP, URN
 from .service import Service
 from .order import Order
 from .artifact import Artifact

--- a/src/ivcap_client/errors.py
+++ b/src/ivcap_client/errors.py
@@ -3,6 +3,10 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file. See the AUTHORS file for names of contributors.
 #
+
+#
+#### DO NOT EDIT ####
+#
 """ Contains shared errors types that can be raised from API functions """
 
 

--- a/src/ivcap_client/ivcap.py
+++ b/src/ivcap_client/ivcap.py
@@ -24,9 +24,10 @@ from ivcap_client.metadata import Metadata, MetadataIter
 from ivcap_client.models.add_meta_rt import AddMetaRT
 from ivcap_client.order import Order, OrderIter
 from ivcap_client.service import Service, ServiceIter
-from ivcap_client.types import URN
 from ivcap_client.utils import process_error
 from ivcap_client.models.metadata_list_item_rt import MetadataListItemRT
+
+URN = str
 
 class IVCAP:
     """A class to represent a particular IVCAP deployment and it's capabilities

--- a/src/ivcap_client/types.py
+++ b/src/ivcap_client/types.py
@@ -3,13 +3,16 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file. See the AUTHORS file for names of contributors.
 #
+
+#
+#### DO NOT EDIT ####
+#
 """ Contains some shared types for properties """
 from http import HTTPStatus
 from typing import BinaryIO, Generic, Literal, MutableMapping, Optional, Tuple, TypeVar
 
 from attrs import define
 
-URN = str
 
 class Unset:
     def __bool__(self) -> Literal[False]:


### PR DESCRIPTION
Moved URN into ivcap.py and also added 'do not edit' warnings into the auto-generated top-level files.